### PR TITLE
build into es5 target instead of es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["es6"],
+    "downlevelIteration": true,
     "module": "commonjs",
     "noImplicitAny": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
+    "lib": ["es6"],
     "module": "commonjs",
     "noImplicitAny": true,
     "strict": true,


### PR DESCRIPTION
Hi!

We're having trouble with UglifyJS - it doesn't support ES6! So it throws errors when it tries to minify your package.
The solution is to transpile the build into ES5 instead of ES6.
This is how all the node_modules that we use transpile code, which seems to be the current standard.