### PR TITLE
Expose birth date

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,33 +28,36 @@ This package exports a functional and object-oriented API for your convenience.
 ### Object-oriented API
 
 ```js
-import { NorwegianId } from 'norwegian-national-id-validator';
+import { NorwegianId } from 'norwegian-national-id-validator';
 
 const validation = NorwegianId('29029600013');
 
-if (validation.isValid())
+console.log(validation.isValid())
 // => true
 
-if (validation.isBirthNumber())
+console.log(validation.isBirthNumber())
 // => true
 
-if (validation.isDNumber())
+console.log(validation.isDNumber())
 // => false
 
-if (validation.isHNumber())
+console.log(validation.isHNumber())
 // => false
 
-if (validation.isFhNumber())
+console.log(validation.isFhNumber())
 // => false
 
-if (validation.isMale())
+console.log(validation.isMale())
 // => false
 
-if (validation.isFemale())
+console.log(validation.isFemale())
 // => true
 
-if (validation.age())
+console.log(validation.age())
 // => 24
+
+console.log(validation.birthDate())
+// => Thu Feb 29 1996 [...]
 ```
 
 ### Functional API

--- a/__test__/object-orient-api.test.ts
+++ b/__test__/object-orient-api.test.ts
@@ -5,6 +5,7 @@ describe('test of object oriented API for ID number validation', () => {
   beforeEach(() => {
     set('06/18/2017');
   });
+  
   afterEach(() => {
     reset();
   });

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ norwegian-national-id-validator
 - [possibleAgeOfPersonWithIdNumber](README.md#possibleageofpersonwithidnumber)
 - [possibleAgesOfPersonWithIdNumber](README.md#possibleagesofpersonwithidnumber)
 - [validateNorwegianIdNumber](README.md#validatenorwegianidnumber)
+- [possibleBirthDateOfIdNumber](README.md#possibleBirthDateOfIdNumber)
 
 ## Functions
 
@@ -48,7 +49,7 @@ const valid = NorwegianId('0000000000');
 
 | Name | Type |
 | :------ | :------ |
-| `age` | () => `undefined` \| `number` |
+| `age` | () => `number` \| `undefined` |
 | `idNumber` | `string` |
 | `isBirthNumber` | () => `boolean` |
 | `isDNumber` | () => `boolean` |
@@ -57,6 +58,7 @@ const valid = NorwegianId('0000000000');
 | `isHNumber` | () => `boolean` |
 | `isMale` | () => `boolean` |
 | `isValid` | () => `boolean` |
+| `birthDate` | () => `Date` \| `undefined` |
 
 ___
 
@@ -213,3 +215,21 @@ const valid = validateNorwegianIdNumber(0000000000);
 `boolean`
 
 `true` for valid, and `false` for invalid ID number.
+
+___
+
+### possibleBirthDateOfIdNumber
+
+▸ **possibleBirthDateOfIdNumber**(`elevenDigits`): `Date` \| `undefined`
+
+Returns the birth date of a person with the given Norwegian national identity number as Date object. Returns `undefined` when birth date could not be determined (e.g. for FH-numbers and invalid ID-numbers).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `elevenDigits` | `string` | Identification number |
+
+#### Returns
+
+`Date` \| `undefined`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,46 @@
+type NorwegianIdObject = {
+  /** The ID this object was created with */
+  idNumber: string,
+
+  isValid: () => boolean,
+
+  /**
+   * A national identity number (birth number) is an ID number for you who
+   * have a residence permit and are going to live in Norway for more than
+   * six months.
+   */
+  isBirthNumber: () => boolean
+
+  /**
+   * A D number is a temporary identification number that you get if you have
+   * applied for protection (asylum), or if you have a residence permit and
+   * are going to stay in Norway for less than six months.
+   */
+  isDNumber: () => boolean,
+
+  /**
+   * A H number is a number used for assistance, a unique identification of a
+   * person that does not have a national ID or a D number or in cases where
+   * this is not known. A H number contains information about age and gender.
+   */
+  isHNumber: () => boolean
+
+  /**
+   * A FH number is used in health care to uniquely identify patients that
+   * does not have a known national ID or D number. A FH number does not have
+   * any information about age or gender.
+   */
+  isFhNumber: () => boolean,
+
+  isMale: () => boolean,
+
+  isFemale: () => boolean,
+
+  age: () => number | undefined
+
+  birthDate: () => Date | undefined
+}
+
 /**
  * Object-oriented API for Norwegian National ID Validator
  * @example
@@ -8,46 +51,25 @@
  * ```
  * @param idNumber norwegian social security number
  */
-export const NorwegianId = (idNumber: string) => {
+export const NorwegianId = (idNumber: string): NorwegianIdObject => {
   const valid = validateNorwegianIdNumber(idNumber);
 
   return {
-    /** The ID this object was created with */
     idNumber,
     isValid: () => valid,
 
-    /**
-     * A national identity number (birth number) is an ID number for you who
-     * have a residence permit and are going to live in Norway for more than
-     * six months.
-     */
     isBirthNumber: () =>
       valid && idNumberType(idNumber) == IDNumberType.BirthNumber,
 
-    /**
-     * A D number is a temporary identification number that you get if you have
-     * applied for protection (asylum), or if you have a residence permit and
-     * are going to stay in Norway for less than six months.
-     */
     isDNumber: () => valid && idNumberType(idNumber) == IDNumberType.DNumber,
 
-    /**
-     * A H number is a number used for assistance, a unique identification of a
-     * person that does not have a national ID or a D number or in cases where
-     * this is not known. A H number contains information about age and gender.
-     */
     isHNumber: () => valid && idNumberType(idNumber) == IDNumberType.HNumber,
 
-    /**
-     * A FH number is used in health care to uniquely identify patients that
-     * does not have a known national ID or D number. A FH number does not have
-     * any information about age or gender.
-     */
     isFhNumber: () => valid && idNumberType(idNumber) == IDNumberType.FHNumber,
     isMale: () => valid && getGender(idNumber) == Gender.Male,
     isFemale: () => valid && getGender(idNumber) == Gender.Female,
     age: () => possibleAgeOfPersonWithIdNumber(idNumber),
-    birthDate: () => valid && possibleBirthDateOfIdNumber(idNumber),
+    birthDate: () => (valid && possibleBirthDateOfIdNumber(idNumber)) || undefined,
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export const NorwegianId = (idNumber: string) => {
     isMale: () => valid && getGender(idNumber) == Gender.Male,
     isFemale: () => valid && getGender(idNumber) == Gender.Female,
     age: () => possibleAgeOfPersonWithIdNumber(idNumber),
+    birthDate: () => valid && possibleBirthDateOfIdNumber(idNumber),
   };
 };
 
@@ -190,7 +191,7 @@ export function idNumberContainsBirthDate(elevenDigits: string): boolean {
  * Get possible birth date from ID number
  * @param elevenDigits IdNumber
  */
-function possibleBirthDateOfIdNumber(elevenDigits: string): Date | undefined {
+export function possibleBirthDateOfIdNumber(elevenDigits: string): Date | undefined {
   if (elevenDigits.length !== 11) return undefined;
   const type = idNumberType(elevenDigits);
   switch (type) {


### PR DESCRIPTION
This PR adds `birthDate` as a function on the object API and alls exposes the `possibleBirthDateOfIdNumber` function that was not exported before.

Having a way of getting the birthDate for an ID number would be handy, and would mean that we could stop doing chekcs for id types, subtract 4 from the 3rd digit of D-numbers etc.