### PR TITLE
build(renovate): pin dependiences

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>mikaello/renovate-presets"],
   "schedule": ["before 3am on Monday"],
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Change [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) to `pin`, this will make the builds more reliable.