### PR TITLE
fix: correct age calculation for people born on Feb 29

### DIFF
--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -161,6 +161,17 @@ describe('helper functions', () => {
     expect(diffYears(new Date('1995-01-01'), new Date('1993-06-01'))).toBe(1);
   });
 
+  test('diffYears() counts leap day birthday on Feb 28 in non-leap years', () => {
+    const leapDayBirth = new Date('2000-02-29');
+    expect(diffYears(new Date('2025-02-27'), leapDayBirth)).toBe(24);
+    expect(diffYears(new Date('2025-02-28'), leapDayBirth)).toBe(25);
+    expect(diffYears(new Date('2025-03-01'), leapDayBirth)).toBe(25);
+    // Actual leap day — birthday on Feb 29
+    expect(diffYears(new Date('2024-02-28'), leapDayBirth)).toBe(23);
+    expect(diffYears(new Date('2024-02-29'), leapDayBirth)).toBe(24);
+    expect(diffYears(new Date('2024-03-01'), leapDayBirth)).toBe(24);
+  });
+
   test('isValiddate() returns valid for valid dates', () => {
     expect(
       isValidDate(new Date('1995-01-20'), '1995', '01', '20'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,14 @@ export function diffYears(startDate: Date, endDate: Date) {
   const mEnd = endDate.getMonth();
   const dEnd = endDate.getDate();
 
+  // Feb 29 birthdays are observed on Feb 28 in non-leap years
+  const isLeapYear = (y: number) =>
+    (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+  const effectiveDEnd =
+    mEnd === 1 && dEnd === 29 && !isLeapYear(yStart) ? 28 : dEnd;
+
   const diff = yStart - yEnd;
-  if (mEnd > mStart || (mEnd === mStart && dEnd > dStart)) {
+  if (mEnd > mStart || (mEnd === mStart && effectiveDEnd > dStart)) {
     return diff - 1;
   }
 


### PR DESCRIPTION
In non-leap years, the birthday of someone born on Feb 29 is observed on Feb 28. The previous diffYears logic compared against day 29 literally, causing the age to stay one year too low on Feb 28 and only increment on March 1.

Fixes #225